### PR TITLE
fixed problem with padding samples up to integral number of frames

### DIFF
--- a/fgnt/signal_processing.py
+++ b/fgnt/signal_processing.py
@@ -131,11 +131,16 @@ def stft(time_signal, time_dim=None, size=1024, shift=256,
         time_signal = np.pad(time_signal, pad, mode='constant')
 
     # Pad with trailing zeros, to have an integral number of frames.
-    frames = _samples_to_stft_frames(time_signal.shape[time_dim], size, shift)
-    samples = _stft_frames_to_samples(frames, size, shift)
-    pad = [(0, 0)] * time_signal.ndim
-    pad[time_dim] = [0, samples - time_signal.shape[time_dim]]
-    time_signal = np.pad(time_signal, pad, mode='constant')
+    currentSamples = time_signal.shape[time_dim]
+    frames = _samples_to_stft_frames(currentSamples, size, shift)
+    samplesWithIntegralNumberOfFrames = _stft_frames_to_samples(frames, size, shift)
+    assert samplesWithIntegralNumberOfFrames <= currentSamples
+    if (currentSamples > samplesWithIntegralNumberOfFrames):
+        newSamples = _stft_frames_to_samples(frames + 1, size, shift)
+        assert newSamples > currentSamples
+        pad = [(0, 0)] * time_signal.ndim
+        pad[time_dim] = (0, newSamples - currentSamples)
+        time_signal = np.pad(time_signal, pad, mode='constant')
 
     if window_length is None:
         window = window(size)

--- a/tests/signal_processing/stft.py
+++ b/tests/signal_processing/stft.py
@@ -1,0 +1,15 @@
+import unittest
+
+import numpy as np
+
+from fgnt.signal_processing import stft
+
+
+class TestStft(unittest.TestCase):
+    def testSyntheticNoise_StftShouldNotFail(self):
+        noise = np.random.randn(6, 61538)
+        spectrogram = stft(noise)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hello!

I had a problem with padding while running the script `chime_data.py` on the CHiME3 dataset. The code supplied negative numbers to the `np.pad` function.

I believe, it is a bug because the function `_samples_to_stft_frames` cannot return more frames than necessary i.e. the restored number of samples, which is:

`samples = _stft_frames_to_samples(frames, size, shift)`

cannot exceed the current number of samples which is `time_signal.shape[time_dim]`

The new number of samples can be calculated by adding an additional frame:

`newSamples = _stft_frames_to_samples(frames + 1, size, shift)`